### PR TITLE
Refactor: extract reader traits into standalone crate (data_trans_reader)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,7 @@ dependencies = [
  "clap",
  "config",
  "dashmap",
+ "data_trans_reader",
  "dirs-next",
  "flutter_rust_bridge",
  "futures",
@@ -583,6 +584,15 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.8.2",
+]
+
+[[package]]
+name = "data_trans_reader"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [ 
     "data_trans_core", 
     "data_trans_cli",
+    "data_trans_reader",
     "my_app/rust"
 ]
 resolver = "2"

--- a/data_trans_core/Cargo.toml
+++ b/data_trans_core/Cargo.toml
@@ -26,6 +26,7 @@ dirs-next = "2.0"
 dashmap = "5"
 futures = "0.3"
 async-trait = "0.1"
+data_trans_reader = { path = "../data_trans_reader" }
 
 
 [dev-dependencies]

--- a/data_trans_core/src/core/sync_pipeline.rs
+++ b/data_trans_core/src/core/sync_pipeline.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::collections::{HashMap, BTreeMap};
 use sqlx::{Row, Column};
+use data_trans_reader::{DbReaderDriver, Job, JobSplitResult, Task};
 
 use crate::core::{Config, TypedVal};
 use crate::core::db::{DbKind, DbPool};
@@ -29,58 +30,45 @@ pub enum DataSourceType {
     },
 }
 
-/// 任务（Job Split 切分后的子任务）
-#[derive(Debug, Clone)]
-pub struct Task {
-    pub task_id: usize,
-    pub offset: usize,
-    pub limit: usize,
+pub struct CoreDbReaderDriver {
+    pool: Arc<DbPool>,
 }
 
-/// 任务切分结果
-pub struct JobSplitResult {
-    pub total_records: usize,
-    pub tasks: Vec<Task>,
+impl CoreDbReaderDriver {
+    pub fn new(pool: Arc<DbPool>) -> Self {
+        Self { pool }
+    }
 }
 
-/// Job trait - 定义数据读取任务的通用接口
-#[async_trait::async_trait]
-pub trait Job: Send + Sync {
-    /// 切分任务为多个子任务
-    async fn split(&self, reader_threads: usize) -> Result<JobSplitResult>;
+impl DbReaderDriver for CoreDbReaderDriver {
+    type Pool = DbPool;
 
-    /// 执行单个任务，读取数据并发送到 Channel
-    async fn execute_task(
-        &self,
-        task: Task,
-        tx: mpsc::Sender<PipelineMessage>,
-    ) -> Result<usize>;
-
-    /// 获取任务描述（用于日志）
-    fn description(&self) -> String;
+    fn pool(&self) -> &Self::Pool {
+        self.pool.as_ref()
+    }
 }
 
 /// 数据库 Job 实现
 pub struct DatabaseJob {
     config: Arc<Config>,
-    pool: Arc<DbPool>,
+    db_reader: Arc<dyn DbReaderDriver<Pool = DbPool>>,
 }
 
 impl DatabaseJob {
-    pub fn new(config: Arc<Config>, pool: Arc<DbPool>) -> Self {
-        Self { config, pool }
+    pub fn new(config: Arc<Config>, db_reader: Arc<dyn DbReaderDriver<Pool = DbPool>>) -> Self {
+        Self { config, db_reader }
     }
 }
 
 #[async_trait::async_trait]
-impl Job for DatabaseJob {
+impl Job<PipelineMessage> for DatabaseJob {
     async fn split(&self, reader_threads: usize) -> Result<JobSplitResult> {
         let db_config = Config::parse_db_config(&self.config.input)?;
         let table = &db_config.table;
 
         let sql = format!("SELECT COUNT(*) as count FROM {}", table);
 
-        let total = match self.pool.as_ref() {
+        let total = match self.db_reader.pool() {
             DbPool::Postgres(pg_pool) => {
                 sqlx::query_scalar::<_, i64>(&sql)
                     .fetch_one(pg_pool)
@@ -141,7 +129,7 @@ impl Job for DatabaseJob {
         let mut sent = 0;
         let mut buffer = Vec::with_capacity(100);
 
-        match self.pool.as_ref() {
+        match self.db_reader.pool() {
             DbPool::Postgres(pg_pool) => {
                 let mut stream = sqlx::query(&sql).fetch(pg_pool);
 
@@ -244,7 +232,7 @@ impl ApiJob {
 }
 
 #[async_trait::async_trait]
-impl Job for ApiJob {
+impl Job<PipelineMessage> for ApiJob {
     async fn split(&self, _reader_threads: usize) -> Result<JobSplitResult> {
         Ok(JobSplitResult {
             total_records: 0,
@@ -871,9 +859,12 @@ impl Pipeline {
             DataSourceType::Database { .. } => {
                 println!("📊 数据库数据源，启动任务切分...");
 
-                let job: Arc<dyn Job> = Arc::new(DatabaseJob::new(
+                let db_reader: Arc<dyn DbReaderDriver<Pool = DbPool>> = Arc::new(
+                    CoreDbReaderDriver::new(Arc::clone(&self.pool)),
+                );
+                let job: Arc<dyn Job<PipelineMessage>> = Arc::new(DatabaseJob::new(
                     Arc::clone(&self.config),
-                    Arc::clone(&self.pool),
+                    db_reader,
                 ));
 
                 println!("📋 Job: {}", job.description());
@@ -900,7 +891,7 @@ impl Pipeline {
             DataSourceType::Api => {
                 println!("📊 API 数据源，使用单 Reader");
 
-                let job: Arc<dyn Job> = Arc::new(ApiJob::new(Arc::clone(&self.config)));
+                let job: Arc<dyn Job<PipelineMessage>> = Arc::new(ApiJob::new(Arc::clone(&self.config)));
                 println!("📋 Job: {}", job.description());
 
                 let split_result = job.split(1).await?;

--- a/data_trans_reader/Cargo.toml
+++ b/data_trans_reader/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "data_trans_reader"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+tokio = { workspace = true, features = ["sync"] }

--- a/data_trans_reader/src/lib.rs
+++ b/data_trans_reader/src/lib.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use tokio::sync::mpsc;
+
+/// 任务（Job Split 切分后的子任务）
+#[derive(Debug, Clone)]
+pub struct Task {
+    pub task_id: usize,
+    pub offset: usize,
+    pub limit: usize,
+}
+
+/// 任务切分结果
+pub struct JobSplitResult {
+    pub total_records: usize,
+    pub tasks: Vec<Task>,
+}
+
+/// Job trait - 定义数据读取任务的通用接口
+#[async_trait::async_trait]
+pub trait Job<M>: Send + Sync
+where
+    M: Send + 'static,
+{
+    /// 切分任务为多个子任务
+    async fn split(&self, reader_threads: usize) -> Result<JobSplitResult>;
+
+    /// 执行单个任务，读取数据并发送到 Channel
+    async fn execute_task(&self, task: Task, tx: mpsc::Sender<M>) -> Result<usize>;
+
+    /// 获取任务描述（用于日志）
+    fn description(&self) -> String;
+}
+
+/// db.reader 驱动抽象：用于为 Reader 提供数据库连接池
+pub trait DbReaderDriver: Send + Sync {
+    type Pool: Send + Sync;
+
+    fn pool(&self) -> &Self::Pool;
+}


### PR DESCRIPTION
### Motivation
- Decouple reader abstractions from core pipeline so `sync_pipeline` can depend on a small trait-only crate and allow external `db.reader` drivers to provide connection pools.
- Make the database reader driver a pluggable abstraction (`DbReaderDriver`) while keeping reader internals unchanged.

### Description
- Add a new workspace crate `data_trans_reader` that defines `Task`, `JobSplitResult`, a generic `Job<M>` trait and `DbReaderDriver` trait to hold reader-side abstractions. 
- Wire the workspace and `data_trans_core` to depend on the new crate by updating `Cargo.toml` and adding `data_trans_reader` as a path dependency. 
- Update `data_trans_core/src/core/sync_pipeline.rs` to consume the traits from `data_trans_reader`, remove local `Job/Task/JobSplitResult` definitions, and introduce `CoreDbReaderDriver` as a concrete `DbReaderDriver` implementation that exposes the existing `DbPool`. 
- Change `DatabaseJob` construction and usage to obtain the pool via the `DbReaderDriver` trait (type `Arc<dyn DbReaderDriver<Pool = DbPool>>`) and adapt `Job` usage to the generic `Job<PipelineMessage>` trait while preserving reader execution logic.

### Testing
- Ran `cargo check -p data_trans_core` which completed successfully. 
- Executed core examples with: `cargo run -p data_trans_core --example test_config_watch`, `test_sync_command_new`, `test_persistence_flow`, and `test_update_config`, and all examples finished successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63ce97a6c832aa8dd8232a487c4ff)