### PR TITLE
Remove deprecated DataSourceKind and clean up runner.rs

### DIFF
--- a/data_trans_core/src/core/runner.rs
+++ b/data_trans_core/src/core/runner.rs
@@ -170,43 +170,6 @@ impl Runner {
     }
 }
 
-// ==========================================
-// 数据源类型
-// ==========================================
-
-/// 数据源类型标识
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct DataSourceKind(pub String);
-
-impl DataSourceKind {
-    pub fn api() -> Self {
-        Self("api".to_string())
-    }
-    pub fn database() -> Self {
-        Self("database".to_string())
-    }
-    pub fn kafka() -> Self {
-        Self("kafka".to_string())
-    }
-    pub fn new(name: &str) -> Self {
-        Self(name.to_string())
-    }
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<&str> for DataSourceKind {
-    fn from(s: &str) -> Self {
-        Self(s.to_string())
-    }
-}
-
-impl std::fmt::Display for DataSourceKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 /// 根据配置动态创建 Reader/Writer 并执行同步
 ///
 /// 通过 GlobalRegistry 根据 source_type 动态创建对应的数据源实例，


### PR DESCRIPTION
### Motivation
- Remove the obsolete `DataSourceKind` wrapper type which duplicated simple string-based source identifiers and is no longer needed.

### Description
- Deleted the `DataSourceKind` struct and its associated impls (`api`, `database`, `kafka`, `new`, `as_str`, `From<&str>`, and `Display`) from `data_trans_core/src/core/runner.rs`.
- Continued to use string-based source type keys via `config.input.source_type` and `config.output.source_type` when creating readers and writers through `GlobalRegistry` in `run_sync`.
- Removed the related header comment block to reduce clutter in the file.

### Testing
- Ran `cargo build` to ensure the crate compiles after the removal and no references to `DataSourceKind` remain.
- Ran the test suite with `cargo test` and all existing unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a027191c832aa88eeec79d33371a)